### PR TITLE
fix for: buggy android add-on native-ui-boilerplate, Bugzilla #1176002

### DIFF
--- a/boilerplate/native-ui-boilerplate/bootstrap.js
+++ b/boilerplate/native-ui-boilerplate/bootstrap.js
@@ -65,6 +65,8 @@ function unloadFromWindow(window) {
 var windowListener = {
   onOpenWindow: function(aWindow) {
     // Wait for the window to finish loading
+    let domWindow = aWindow.QueryInterface(Ci.nsIInterfaceRequestor)
+            .getInterface(Ci.nsIDOMWindowInternal || Ci.nsIDOMWindow);
     function loadListener() {
       domWindow.removeEventListener("load", loadListener, false);
       loadIntoWindow(domWindow);


### PR DESCRIPTION
bootstrap.js, line 66: the domWindow variable initialization
has been removed last year from the onOpenWindow handler,
therefore causing subsequent calls to domWindow methods fail:
https://github.com/mozilla/firefox-for-android-addons/commit/45c85215a89c9a965cf99378b9bca30c6d3ce1b3

I simply restored that very initialization line from commit history,
since I did not get any resonance about whether 
Ci.nsIDOMWindowInternal is deprecated or dirty, 
and I do not feel having the Authority to decide this.

Wrapped the single-line patch into a pull req, hope it helps. :-)